### PR TITLE
Hex prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,18 @@ For cases where you need a full hex string without leading zero compression we'v
 let encoded:String = data.fullHexEncodedString()
 ```
 
+Hex strings are commonly prefixed with `0x` in the crypto world. `0x` prefixes are automatically stripped when decoding. To automatically add `0x` during hex encoding pass in `true` to either `hexEncodedString()` or `fullHexEncodedString()`.
+
 For `String` we include the `decodeHex()` and `decodeBase58()` methods as an extension.
 
 ```swift
 import SwiftBaseX
 
 let decoded: Data = "Cn8eVZg".decodeBase58()
+```
+For cases where you need to decode a full hex string without leading zero compression we've also included the following variation.
+
+```swift
+let encoded:String = data.decodeFullHex()
 ```
 

--- a/SwiftBaseXTests/SwiftBaseXTests.swift
+++ b/SwiftBaseXTests/SwiftBaseXTests.swift
@@ -41,22 +41,34 @@ class SwiftBaseXTests: XCTestCase {
     }
     
     func testHexDecode() {
-        XCTAssertEqual(decode(alpha:HEX, data:"68656c6c6f"), "hello".data(using: String.Encoding.utf8)!)
+        XCTAssertEqual(try! decode(alpha:HEX, data:"68656c6c6f"), "hello".data(using: String.Encoding.utf8)!)
+    }
+
+    func testHexDecodeInvalid() {
+        XCTAssertThrowsError(try decode(alpha:HEX, data:"68656c6c6g"))
+        XCTAssertThrowsError(try decode(alpha:HEX, data:"68656c6c6f "))
+        XCTAssertThrowsError(try decode(alpha:HEX, data:" 68656c6c6f"))
     }
     
     func testBase58Decode() {
-        XCTAssertEqual(decode(alpha:BASE58, data:"Cn8eVZg"), "hello".data(using: String.Encoding.utf8)!)
+        XCTAssertEqual(try! decode(alpha:BASE58, data:"Cn8eVZg"), "hello".data(using: String.Encoding.utf8)!)
     }
-    
+
+    func testBsse58DecodeInvalid() {
+        XCTAssertThrowsError(try decode(alpha:BASE58, data:"Cn8eVZg=="))
+        XCTAssertThrowsError(try decode(alpha:BASE58, data:"Cn8eVZg "))
+        XCTAssertThrowsError(try decode(alpha:BASE58, data:" Cn8eVZg"))
+    }
+
     func testHexDecodeExtension() {
-        XCTAssertEqual("68656c6c6f".decodeHex(), "hello".data(using: String.Encoding.utf8)!)
-        XCTAssertEqual("0x68656c6c6f".decodeHex(), "hello".data(using: String.Encoding.utf8)!)
-        XCTAssertEqual("68656c6c6f".decodeFullHex(), "hello".data(using: String.Encoding.utf8)!)
-        XCTAssertEqual("0x68656c6c6f".decodeFullHex(), "hello".data(using: String.Encoding.utf8)!)
+        XCTAssertEqual(try! "68656c6c6f".decodeHex(), "hello".data(using: String.Encoding.utf8)!)
+        XCTAssertEqual(try! "0x68656c6c6f".decodeHex(), "hello".data(using: String.Encoding.utf8)!)
+        XCTAssertEqual(try! "68656c6c6f".decodeFullHex(), "hello".data(using: String.Encoding.utf8)!)
+        XCTAssertEqual(try! "0x68656c6c6f".decodeFullHex(), "hello".data(using: String.Encoding.utf8)!)
     }
 
     func testBase58DecodeExtension() {
-        XCTAssertEqual("Cn8eVZg".decodeBase58(), "hello".data(using: String.Encoding.utf8)!)
+        XCTAssertEqual(try! "Cn8eVZg".decodeBase58(), "hello".data(using: String.Encoding.utf8)!)
     }
 
     func testAllHexEncode() {
@@ -71,16 +83,16 @@ class SwiftBaseXTests: XCTestCase {
     func testAllHexDecode() {
         let fixtures = parseTestCases("valid")
         for pair in fixtures {
-            XCTAssertEqual(pair["hex"]?.decodeHex(), pair["base64"]?.decodeBase64())
+            XCTAssertEqual(try! pair["hex"]?.decodeHex(), pair["base64"]?.decodeBase64())
             let fullHex = pair["fullhex"] != nil ? pair["fullhex"] : pair["hex"]
-            XCTAssertEqual(fullHex?.decodeFullHex(), pair["base64"]?.decodeBase64() )
+            XCTAssertEqual(try! fullHex?.decodeFullHex(), pair["base64"]?.decodeBase64() )
         }
     }
 
     func testAllBase58Decode() {
         let fixtures = parseTestCases("valid")
         for pair in fixtures {
-            XCTAssertEqual(pair["base58"]?.decodeBase58(), pair["base64"]?.decodeBase64())
+            XCTAssertEqual(try! pair["base58"]?.decodeBase58(), pair["base64"]?.decodeBase64())
         }
     }
 

--- a/SwiftBaseXTests/SwiftBaseXTests.swift
+++ b/SwiftBaseXTests/SwiftBaseXTests.swift
@@ -31,6 +31,9 @@ class SwiftBaseXTests: XCTestCase {
 
     func testHexEncodeExtension() {
         XCTAssertEqual("hello".data(using: String.Encoding.utf8)!.hexEncodedString(), "68656c6c6f")
+        XCTAssertEqual("hello".data(using: String.Encoding.utf8)!.hexEncodedString(true), "0x68656c6c6f")
+        XCTAssertEqual("hello".data(using: String.Encoding.utf8)!.fullHexEncodedString(), "68656c6c6f")
+        XCTAssertEqual("hello".data(using: String.Encoding.utf8)!.fullHexEncodedString(true), "0x68656c6c6f")
     }
 
     func testBase58EncodeExtension() {
@@ -47,6 +50,9 @@ class SwiftBaseXTests: XCTestCase {
     
     func testHexDecodeExtension() {
         XCTAssertEqual("68656c6c6f".decodeHex(), "hello".data(using: String.Encoding.utf8)!)
+        XCTAssertEqual("0x68656c6c6f".decodeHex(), "hello".data(using: String.Encoding.utf8)!)
+        XCTAssertEqual("68656c6c6f".decodeFullHex(), "hello".data(using: String.Encoding.utf8)!)
+        XCTAssertEqual("0x68656c6c6f".decodeFullHex(), "hello".data(using: String.Encoding.utf8)!)
     }
 
     func testBase58DecodeExtension() {
@@ -66,6 +72,8 @@ class SwiftBaseXTests: XCTestCase {
         let fixtures = parseTestCases("valid")
         for pair in fixtures {
             XCTAssertEqual(pair["hex"]?.decodeHex(), pair["base64"]?.decodeBase64())
+            let fullHex = pair["fullhex"] != nil ? pair["fullhex"] : pair["hex"]
+            XCTAssertEqual(fullHex?.decodeFullHex(), pair["base64"]?.decodeBase64() )
         }
     }
 


### PR DESCRIPTION
- [x] auto strips `0x` from hex strings
- [x] option to add `0x` during hex encoding
- [x] `decodeFullHex()` to decode regular hex strings
- [x] better error handling