### PR TITLE
Explicit function call

### DIFF
--- a/SwiftBaseX/BaseX.swift
+++ b/SwiftBaseX/BaseX.swift
@@ -116,7 +116,7 @@ func strip0x(_ hex: String) -> String {
 
 public extension Data {
     public func hexEncodedString(_ prefixed: Bool = false) -> String {
-        let encoded = encode(alpha:HEX, data: self)
+        let encoded = SwiftBaseX.encode(alpha:HEX, data: self)
         if prefixed {
             return "0x".appending(encoded)
         }
@@ -133,7 +133,7 @@ public extension Data {
     }
 
     public func base58EncodedString() -> String {
-        return encode(alpha:BASE58, data: self)
+        return SwiftBaseX.encode(alpha:BASE58, data: self)
     }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14796429/29617621-69cc7aa6-8850-11e7-945c-3f739c70ef3a.png)

Compiler error with Swift 4, Xcode 9